### PR TITLE
送付先住所の改修

### DIFF
--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -26,10 +26,20 @@
 
 <%= form_for @order do |f| %>
 
+<% ad_nm = current_user.address_names.map{|an| [an.address_name,an.address_name]} %>
+<% ad_nm.unshift([current_user.lastname + current_user.firstname , current_user.lastname + current_user.firstname])  %>
+
+<% pc_ad = current_user.addresses.map{|pc_ad| [pc_ad.postalcode + pc_ad.address , pc_ad.postalcode + pc_ad.address]} %>
+<% pc_ad.unshift([current_user.postalcode + current_user.address, current_user.postalcode + current_user.address])  %>
+
+
+
 <p> 宛名 </p>
-<p><%= f.select :address_name, current_user.address_names.map{|an| [an.address_name,an.address_name] } %></p>
-<p> 送付先住所 </p>
-<p><%= f.select :shipping_address, current_user.addresses.all.map{|a| [a.address,a.address] } %></p>
+<p><%= f.select :address_name, ad_nm %></p>
+<br>
+<p> 送付先 </p>
+<p><%= f.select :shipping_address, pc_ad %></p>
+
 
 <br>
 

--- a/db/migrate/20190618093332_add_postalcode_to_orders.rb
+++ b/db/migrate/20190618093332_add_postalcode_to_orders.rb
@@ -1,0 +1,5 @@
+class AddPostalcodeToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :postalcode, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_18_064542) do
+ActiveRecord::Schema.define(version: 2019_06_18_093332) do
 
   create_table "address_names", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -131,6 +131,7 @@ ActiveRecord::Schema.define(version: 2019_06_18_064542) do
     t.string "order_status", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "postalcode"
   end
 
   create_table "reviews", force: :cascade do |t|


### PR DESCRIPTION
・orderテーブルにpostalcodeカラムを追加
・注文確認画面での送付先選択で、ユーザーの登録ユーザー名/住所/郵便番号が一番上に表示されるように
・shipping_addressカラムには、郵便番号と住所をくっつけた物を保存